### PR TITLE
162 - store and check expires_in time for the access_token  

### DIFF
--- a/lib/bwapi/client.rb
+++ b/lib/bwapi/client.rb
@@ -65,11 +65,19 @@ module BWAPI
       end
     end
 
+    # Check is access token has expired
+    #
+    # @return [Boolean] access token expiry status
+    def access_token_expired?
+      return true if @access_token.nil? || @access_token_expiry.nil?
+      seconds_until_access_token_expires <= 0
+    end
+
     # Check if user is authenicated
     #
     # @return [Boolean] Authenticated status
     def authenticated?
-      @access_token ? true : false
+      (@access_token && !access_token_expired?) ? true : false
     end
 
     # Check if user is a brandwatch-application-client type
@@ -114,6 +122,15 @@ module BWAPI
     def verify_ssl=(value)
       reset_connection
       @verify_ssl = value
+    end
+
+    private
+
+    # Returns the number of seconds until the access token expires
+    #
+    # @return [Integer] seconds until expiry
+    def seconds_until_access_token_expires
+      DateTime.parse(@access_token_expiry).to_time.to_i - Time.now.to_i
     end
   end
 end

--- a/lib/bwapi/client/oauth.rb
+++ b/lib/bwapi/client/oauth.rb
@@ -61,7 +61,8 @@ module BWAPI
       # @param opts [Hash] options hash of parameters
       def oauth_request(opts = {})
         response = post('oauth/token', opts)
-        self.access_token  = response['access_token']
+        self.access_token = response['access_token']
+        self.access_token_expiry = Time.at(Time.now.to_i + response['expires_in']).iso8601
         self.refresh_token = response['refresh_token'] if application_client?
         response
       end

--- a/lib/bwapi/configuration.rb
+++ b/lib/bwapi/configuration.rb
@@ -1,8 +1,8 @@
 module BWAPI
   # Configuration module
   module Configuration
-    attr_accessor :access_token, :adapter, :api_endpoint, :client_id, :debug, :grant_type,
-                  :logger, :performance, :refresh_token, :user_agent, :username, :verify_ssl
+    attr_accessor :access_token, :access_token_expiry, :adapter, :api_endpoint, :client_id, :debug,
+                  :grant_type, :logger, :performance, :refresh_token, :user_agent, :username, :verify_ssl
 
     attr_writer :client_secret, :password
 
@@ -11,6 +11,7 @@ module BWAPI
       def keys
         @keys ||= [
           :access_token,
+          :access_token_expiry,
           :adapter,
           :api_endpoint,
           :client_id,

--- a/lib/bwapi/default.rb
+++ b/lib/bwapi/default.rb
@@ -26,8 +26,12 @@ module BWAPI
         ENV['BWAPI_ACCESS_TOKEN']
       end
 
+      def access_token_expiry
+        nil
+      end
+
       def adapter
-        ENV['BWAPI_ADAPTER'] || ADAPTER
+        ENV['BWAPI_ADAPTER'].is_a?(String) ? ENV['BWAPI_ADAPTER'].to_sym : ADAPTER
       end
 
       def api_endpoint
@@ -54,7 +58,7 @@ module BWAPI
       end
 
       def debug
-        ENV['BWAPI_DEBUG'] || false
+        ENV['BWAPI_DEBUG'] == 'true' ? true : false
       end
 
       def grant_type
@@ -86,7 +90,7 @@ module BWAPI
       end
 
       def verify_ssl
-        ENV['BWAPI_VERIFY_SSL'] || false
+        ENV['BWAPI_VERIFY_SSL'] == 'true' ? true : false
       end
     end
   end

--- a/spec/bwapi/client_spec.rb
+++ b/spec/bwapi/client_spec.rb
@@ -1,9 +1,7 @@
 require 'helper'
 
 describe BWAPI::Client do
-  before do
-    BWAPI.reset
-  end
+  before { BWAPI.reset }
 
   describe 'when called' do
     it 'should be a client class instance' do
@@ -12,13 +10,34 @@ describe BWAPI::Client do
   end
 
   describe '.authenticated?' do
-    it 'returns true when authenticated' do
+    it 'returns false when not authenticated' do
       expect(BWAPI::Client.new.authenticated?).to eql(false)
     end
 
-    it 'returns false when not authenticated' do
-      bw = BWAPI::Client.new access_token: 'abcdef-ghijkl-123456-789012'
+    it 'returns true when authenticated' do
+      bw = BWAPI::Client.new access_token: 'abcdef-ghijkl-123456-789012', access_token_expiry: (Time.now + 3600).iso8601
       expect(bw.authenticated?).to eql(true)
+    end
+  end
+
+  describe '.access_token_expired?' do
+    it 'returns true if access_token is set to nil' do
+      expect(BWAPI::Client.new.access_token_expired?).to eql(true)
+    end
+
+    it 'returns true if access_token_expiry is set to nil' do
+      bw = BWAPI::Client.new access_token: 'abcdef-ghijkl-123456-789012'
+      expect(bw.access_token_expired?).to eql(true)
+    end
+
+    it 'returns true if access token has expired' do
+      bw = BWAPI::Client.new access_token: 'abcdef-ghijkl-123456-789012', access_token_expiry: (Time.now - 3600).iso8601
+      expect(bw.access_token_expired?).to eql(true)
+    end
+
+    it 'returns false if access token has not expired' do
+      bw = BWAPI::Client.new access_token: 'abcdef-ghijkl-123456-789012', access_token_expiry: (Time.now + 3600).iso8601
+      expect(bw.access_token_expired?).to eql(false)
     end
   end
 
@@ -45,167 +64,10 @@ describe BWAPI::Client do
     end
   end
 
-  describe 'configuration' do
-    describe 'instance variables' do
-      it 'should create a api_endpoint instance variable' do
-        expect(BWAPI::Client.new.respond_to?(:api_endpoint)).to eq(true)
-      end
-
-      it 'should create a user_agent instance variable' do
-        expect(BWAPI::Client.new.respond_to?(:user_agent)).to eq(true)
-      end
-
-      it 'should create a adapter instance variable' do
-        expect(BWAPI::Client.new.respond_to?(:adapter)).to eq(true)
-      end
-
-      it 'should create a username instance variable' do
-        expect(BWAPI::Client.new.respond_to?(:username)).to eq(true)
-      end
-
-      it 'should create a password instance variable which cannot be accessed' do
-        expect(BWAPI::Client.new.respond_to?(:password)).to eq(false)
-      end
-
-      it 'should create a grant_type instance variable' do
-        expect(BWAPI::Client.new.respond_to?(:grant_type)).to eq(true)
-      end
-
-      it 'should create a access_token instance variable' do
-        expect(BWAPI::Client.new.respond_to?(:access_token)).to eq(true)
-      end
-
-      it 'should create a refresh_token instance variable' do
-        expect(BWAPI::Client.new.respond_to?(:refresh_token)).to eq(true)
-      end
-
-      it 'should create a client_id instance variable' do
-        expect(BWAPI::Client.new.respond_to?(:client_id)).to eq(true)
-      end
-
-      it 'should create a client_secret instance variable which cannot accessed' do
-        expect(BWAPI::Client.new.respond_to?(:client_secret)).to eq(false)
-      end
-
-      it 'should create a logger instance variable' do
-        expect(BWAPI::Client.new.respond_to?(:logger)).to eq(true)
-      end
-    end
-
-    describe 'configuration values' do
-      describe 'default_adapter' do
-        it 'should have a default default_adapter value' do
-          expect(BWAPI::Client.new.adapter).to eql(:net_http)
-        end
-
-        it 'should allow a user to set a default_adapter value' do
-          bw = BWAPI::Client.new adapter: 'custom_adapter'
-          expect(bw.adapter).to eql('custom_adapter')
-        end
-      end
-
-      describe 'user_agent' do
-        it 'should have a default user_agent value' do
-          expect(BWAPI::Client.new.user_agent).to eql("BWAPI Ruby Gem #{BWAPI::VERSION}")
-        end
-
-        it 'should allow a user to set a user_agent value' do
-          bw = BWAPI::Client.new user_agent: 'custom_user_agent'
-          expect(bw.user_agent).to eql('custom_user_agent')
-        end
-      end
-
-      describe 'api_endpoint' do
-        it 'should have a default api_endpoint value' do
-          expect(BWAPI::Client.new.api_endpoint).to eql('https://newapi.brandwatch.com/')
-        end
-
-        it 'should allow a user to set a api_endpoint value' do
-          bw = BWAPI::Client.new api_endpoint: 'http://newapi.custom.brandwatch.com'
-          expect(bw.api_endpoint).to eql('http://newapi.custom.brandwatch.com')
-        end
-      end
-
-      describe 'client_id' do
-        it 'should have a default client_id value' do
-          expect(BWAPI::Client.new.client_id).to eql('brandwatch-api-client')
-        end
-
-        it 'should allow a user to set a client_id value' do
-          bw = BWAPI::Client.new client_id: 'custom_client_id'
-          expect(bw.client_id).to eql('custom_client_id')
-        end
-      end
-
-      describe 'username' do
-        it 'should have a default value of nil for username' do
-          expect(BWAPI::Client.new.username).to eql(nil)
-        end
-
-        it 'should allow a user to set a username value' do
-          bw = BWAPI::Client.new username: 'jonathan@brandwatch.com'
-          expect(bw.username).to eql('jonathan@brandwatch.com')
-        end
-      end
-
-      describe 'password' do
-        it 'should allow a user to set a password value' do
-          bw = BWAPI::Client.new password: 'pa55w0rd'
-          expect(bw.instance_eval { @password }).to eql('pa55w0rd')
-        end
-      end
-
-      describe 'grant_type' do
-        it 'should have a default value of api-password for grant_type' do
-          expect(BWAPI::Client.new.grant_type).to eql('api-password')
-        end
-
-        it 'should allow a user to set a grant_type value' do
-          bw = BWAPI::Client.new grant_type: 'custom_grant_type'
-          expect(bw.grant_type).to eql('custom_grant_type')
-        end
-      end
-
-      describe 'access_token' do
-        it 'should have a default value of nil for access_token' do
-          expect(BWAPI::Client.new.access_token).to eql(nil)
-        end
-
-        it 'should allow a user to set a access_token value' do
-          bw = BWAPI::Client.new access_token: 'abcdef-ghijkl-123456-789012'
-          expect(bw.access_token).to eql('abcdef-ghijkl-123456-789012')
-        end
-      end
-
-      describe 'refresh_token' do
-        it 'should have a default value of nil for refresh_token' do
-          expect(BWAPI::Client.new.refresh_token).to eql(nil)
-        end
-
-        it 'should allow a user to set a refresh_token value' do
-          bw = BWAPI::Client.new refresh_token: 'abcdef-ghijkl-123456-789012'
-          expect(bw.refresh_token).to eql('abcdef-ghijkl-123456-789012')
-        end
-      end
-
-      describe 'client_secret' do
-        it 'should allow a user to set a client_secret value' do
-          bw = BWAPI::Client.new client_secret: 'custom_client_secret'
-          expect(bw.instance_eval { @client_secret }).to eql('custom_client_secret')
-        end
-      end
-
-      describe 'logger' do
-        it 'should have a default value of nil for logger' do
-          expect(BWAPI::Client.new.logger).to eql(nil)
-        end
-
-        it 'should allow a user to set a logger value' do
-          logger = Object.new
-          bw = BWAPI::Client.new logger: logger
-          expect(bw.logger).to eql(logger)
-        end
-      end
+  describe '.seconds_until_access_token_expires' do
+    it 'should return the number of seconds until the access token expires' do
+      bw = BWAPI::Client.new access_token_expiry: (Time.now + 3600).iso8601
+      expect(bw.send(:seconds_until_access_token_expires)).to eql(3600)
     end
   end
 end

--- a/spec/bwapi/configuration_spec.rb
+++ b/spec/bwapi/configuration_spec.rb
@@ -1,0 +1,499 @@
+require 'helper'
+require 'logger'
+
+describe BWAPI::Configuration do
+  let(:bwapi) { BWAPI::Client.new }
+
+  describe 'instance variables' do
+    it 'should create a access_token instance variable' do
+      expect(bwapi.respond_to?(:access_token)).to eq(true)
+    end
+
+    it 'should create a access_token_expiry instance variable' do
+      expect(bwapi.respond_to?(:access_token_expiry)).to eq(true)
+    end
+
+    it 'should create a adapter instance variable' do
+      expect(bwapi.respond_to?(:adapter)).to eq(true)
+    end
+
+    it 'should create a api_endpoint instance variable' do
+      expect(bwapi.respond_to?(:api_endpoint)).to eq(true)
+    end
+
+    it 'should create a client_id instance variable' do
+      expect(bwapi.respond_to?(:client_id)).to eq(true)
+    end
+
+    it 'should create a client_secret instance variable which cannot accessed' do
+      expect(bwapi.respond_to?(:client_secret)).to eq(false)
+    end
+
+    it 'should create a debug instance variable' do
+      expect(bwapi.respond_to?(:debug)).to eq(true)
+    end
+
+    it 'should create a grant_type instance variable' do
+      expect(bwapi.respond_to?(:grant_type)).to eq(true)
+    end
+
+    it 'should create a logger instance variable' do
+      expect(bwapi.respond_to?(:logger)).to eq(true)
+    end
+
+    it 'should create a password instance variable which cannot be accessed' do
+      expect(bwapi.respond_to?(:password)).to eq(false)
+    end
+
+    it 'should create a performance instance variable' do
+      expect(bwapi.respond_to?(:performance)).to eq(true)
+    end
+
+    it 'should create a refresh_token instance variable' do
+      expect(bwapi.respond_to?(:refresh_token)).to eq(true)
+    end
+
+    it 'should create a user_agent instance variable' do
+      expect(bwapi.respond_to?(:user_agent)).to eq(true)
+    end
+
+    it 'should create a username instance variable' do
+      expect(bwapi.respond_to?(:username)).to eq(true)
+    end
+
+    it 'should create a logger instance variable' do
+      expect(bwapi.respond_to?(:logger)).to eq(true)
+    end
+
+    it 'should create a verify_ssl instance variable' do
+      expect(bwapi.respond_to?(:verify_ssl)).to eq(true)
+    end
+  end
+
+  describe 'default and custom values' do
+    before { bwapi.reset }
+
+    describe 'access_token' do
+      it 'should have a default value of nil for access_token' do
+        expect(bwapi.access_token).to eql(nil)
+      end
+
+      it 'should allow a user to set a access_token value' do
+        bwapi.access_token = 'abcdef-ghijkl-123456-789012'
+        expect(bwapi.access_token).to eql('abcdef-ghijkl-123456-789012')
+      end
+    end
+
+    describe 'access_token_expiry' do
+      it 'should have a default value of nil for access_token_expiry' do
+        expect(bwapi.access_token_expiry).to eql(nil)
+      end
+
+      it 'should allow a user to set a access_token_expiry value' do
+        bwapi.access_token_expiry = '2015-01-08T16:13:03-08:00'
+        expect(bwapi.access_token_expiry).to eql('2015-01-08T16:13:03-08:00')
+      end
+    end
+
+    describe 'adapter' do
+      it 'should have a default adapter value' do
+        expect(bwapi.adapter).to eql(:net_http)
+      end
+
+      it 'should allow a user to set a default_adapter value' do
+        bwapi.adapter = 'custom_adapter'
+        expect(bwapi.adapter).to eql('custom_adapter')
+      end
+    end
+
+    describe 'api_endpoint' do
+      it 'should have a default api_endpoint value' do
+        expect(bwapi.api_endpoint).to eql('https://newapi.brandwatch.com/')
+      end
+
+      it 'should allow a user to set a api_endpoint value' do
+        bwapi.api_endpoint = 'http://newapi.custom.brandwatch.com'
+        expect(bwapi.api_endpoint).to eql('http://newapi.custom.brandwatch.com')
+      end
+    end
+
+    describe 'client_id' do
+      it 'should have a default client_id value' do
+        expect(bwapi.client_id).to eql('brandwatch-api-client')
+      end
+
+      it 'should allow a user to set a client_id value' do
+        bwapi.client_id = 'custom_client_id'
+        expect(bwapi.client_id).to eql('custom_client_id')
+      end
+    end
+
+    describe 'client_secret' do
+      it 'should allow a user to set a client_secret value' do
+        bwapi.client_secret = 'custom_client_secret'
+        expect(bwapi.instance_eval { @client_secret }).to eql('custom_client_secret')
+      end
+    end
+
+    describe 'debug' do
+      it 'should have a default debug value' do
+        expect(bwapi.debug).to eql(false)
+      end
+
+      it 'should allow a user to set a debug value' do
+        bwapi.debug = true
+        expect(bwapi.debug).to eql(true)
+      end
+    end
+
+    describe 'grant_type' do
+      it 'should have a default value of api-password for grant_type' do
+        expect(bwapi.grant_type).to eql('api-password')
+      end
+
+      it 'should allow a user to set a grant_type value' do
+        bwapi.grant_type = 'custom_grant_type'
+        expect(bwapi.grant_type).to eql('custom_grant_type')
+      end
+    end
+
+    describe 'logger' do
+      it 'should have a default value of nil for logger' do
+        expect(bwapi.logger).to eql(nil)
+      end
+
+      it 'should allow a user to set a logger value' do
+        logger = Logger.new(STDOUT)
+        bwapi.logger = logger
+        expect(bwapi.logger).to eql(logger)
+      end
+    end
+
+    describe 'password' do
+      it 'should allow a user to set a password value' do
+        bwapi.password = 'pa55w0rd'
+        expect(bwapi.instance_eval { @password }).to eql('pa55w0rd')
+      end
+    end
+
+    describe 'performance' do
+      it 'should have a default performance value' do
+        expect(bwapi.performance).to eql({})
+      end
+    end
+
+    describe 'refresh_token' do
+      it 'should have a default value of nil for refresh_token' do
+        expect(bwapi.refresh_token).to eql(nil)
+      end
+
+      it 'should allow a user to set a refresh_token value' do
+        bwapi.refresh_token = 'abcdef-ghijkl-123456-789012'
+        expect(bwapi.refresh_token).to eql('abcdef-ghijkl-123456-789012')
+      end
+    end
+
+    describe 'user_agent' do
+      it 'should have a default user_agent value' do
+        expect(bwapi.user_agent).to eql("BWAPI Ruby Gem #{BWAPI::VERSION}")
+      end
+
+      it 'should allow a user to set a user_agent value' do
+        bwapi.user_agent = 'custom_user_agent'
+        expect(bwapi.user_agent).to eql('custom_user_agent')
+      end
+    end
+
+    describe 'username' do
+      it 'should have a default value of nil for username' do
+        expect(bwapi.username).to eql(nil)
+      end
+
+      it 'should allow a user to set a username value' do
+        bwapi.username = 'jonathan@brandwatch.com'
+        expect(bwapi.username).to eql('jonathan@brandwatch.com')
+      end
+    end
+
+    describe 'verify_ssl' do
+      it 'should have a default verify_ssl value' do
+        expect(bwapi.verify_ssl).to eql(false)
+      end
+
+      it 'should allow a user to set a verify_ssl value' do
+        bwapi.verify_ssl = true
+        expect(bwapi.verify_ssl).to eql(true)
+      end
+    end
+  end
+
+  describe '.keys' do
+    it 'should return the correct list of keys' do
+      expect(BWAPI::Configuration.keys).to eql([
+        :access_token,
+        :access_token_expiry,
+        :adapter,
+        :api_endpoint,
+        :client_id,
+        :client_secret,
+        :connection_options,
+        :debug,
+        :grant_type,
+        :logger,
+        :password,
+        :performance,
+        :refresh_token,
+        :user_agent,
+        :username,
+        :verify_ssl
+      ])
+    end
+  end
+
+  describe '.configure' do
+    before do
+      bwapi.configure do |c|
+        c.access_token = '1234-5678-9010-1112'
+        c.access_token_expiry = '2015-01-08 14:09:16 -0800'
+        c.adapter = :test
+        c.api_endpoint = 'http://newapi.test.brandwatch.com'
+        c.client_id = 'brandwatch-test-client'
+        c.client_secret = 'test'
+        c.debug = true
+        c.grant_type = 'test-grant'
+        c.logger = Logger.new(STDOUT)
+        c.password = 'password123'
+        c.refresh_token = '1234-5678-9010-1112'
+        c.user_agent = 'Test User Agent'
+        c.username = 'testing@brandwatch.com'
+        c.verify_ssl = true
+      end
+    end
+
+    after { bwapi.reset }
+
+    it 'should set the configured access_token' do
+      expect(bwapi.access_token).to eql('1234-5678-9010-1112')
+    end
+
+    it 'should set the configured access_token_expiry' do
+      expect(bwapi.access_token_expiry).to eql('2015-01-08 14:09:16 -0800')
+    end
+
+    it 'should set the configured adapter' do
+      expect(bwapi.adapter).to eql(:test)
+    end
+
+    it 'should set the configured api_endpoint' do
+      expect(bwapi.api_endpoint).to eql('http://newapi.test.brandwatch.com')
+    end
+
+    it 'should set the configured client_id' do
+      expect(bwapi.client_id).to eql('brandwatch-test-client')
+    end
+
+    it 'should set the configured client_secret' do
+      expect(bwapi.instance_variable_get(:@client_secret)).to eql('test')
+    end
+
+    it 'should set the configured debug flag' do
+      expect(bwapi.debug).to eql(true)
+    end
+
+    it 'should set the configured grant type' do
+      expect(bwapi.grant_type).to eql('test-grant')
+    end
+
+    it 'should set the configured logger' do
+      expect(bwapi.logger).to be_an_instance_of Logger
+    end
+
+    it 'should set the configured password' do
+      expect(bwapi.instance_variable_get(:@password)).to eql('password123')
+    end
+
+    it 'should set the configured refresh_token' do
+      expect(bwapi.refresh_token).to eql('1234-5678-9010-1112')
+    end
+
+    it 'should set the configured user agent' do
+      expect(bwapi.user_agent).to eql('Test User Agent')
+    end
+
+    it 'should set the configured username' do
+      expect(bwapi.username).to eql('testing@brandwatch.com')
+    end
+
+    it 'should set the configured verify_ssl flag' do
+      expect(bwapi.verify_ssl).to eql(true)
+    end
+  end
+
+  describe '.reset' do
+    before { bwapi.reset }
+
+    it 'should reset the access token value' do
+      expect(bwapi.access_token).to eql(nil)
+    end
+
+    it 'should reset the access token expiry value' do
+      expect(bwapi.access_token_expiry).to eql(nil)
+    end
+
+    it 'should reset the adapter value' do
+      expect(bwapi.adapter).to eql(:net_http)
+    end
+
+    it 'should reset the api_endpoint value' do
+      expect(bwapi.api_endpoint).to eql('https://newapi.brandwatch.com/')
+    end
+
+    it 'should reset the client_id value' do
+      expect(bwapi.client_id).to eql('brandwatch-api-client')
+    end
+
+    it 'should reset the client_secret value' do
+      expect(bwapi.instance_variable_get(:@client_secret)).to eql(nil)
+    end
+
+    it 'should reset the connection value' do
+      expect(bwapi.instance_variable_get(:@connection)).to eql(nil)
+    end
+
+    it 'should reset the debug value' do
+      expect(bwapi.debug).to eql(false)
+    end
+
+    it 'should reset the grant_type value' do
+      expect(bwapi.grant_type).to eql('api-password')
+    end
+
+    it 'should reset the logger value' do
+      expect(bwapi.logger).to eql(nil)
+    end
+
+    it 'should reset the password value' do
+      expect(bwapi.instance_variable_get(:@password)).to eql(nil)
+    end
+
+    it 'should reset the performance value' do
+      expect(bwapi.performance).to eql({})
+    end
+
+    it 'should reset the refresh_token value' do
+      expect(bwapi.refresh_token).to eql(nil)
+    end
+
+    it 'should reset the user_agent value' do
+      expect(bwapi.user_agent).to eql('BWAPI Ruby Gem 10.0.0')
+    end
+
+    it 'should reset the username value' do
+      expect(bwapi.username).to eql(nil)
+    end
+
+    it 'should reset the verify_ssl value' do
+      expect(bwapi.verify_ssl).to eql(false)
+    end
+  end
+
+  describe '.destroy' do
+    before { bwapi.destroy }
+
+    it 'should reset the access token value' do
+      expect(bwapi.access_token).to eql(nil)
+    end
+
+    it 'should reset the access token expiry value' do
+      expect(bwapi.access_token_expiry).to eql(nil)
+    end
+
+    it 'should reset the adapter value' do
+      expect(bwapi.adapter).to eql(nil)
+    end
+
+    it 'should reset the api_endpoint value' do
+      expect(bwapi.api_endpoint).to eql(nil)
+    end
+
+    it 'should reset the client_id value' do
+      expect(bwapi.client_id).to eql(nil)
+    end
+
+    it 'should reset the client_secret value' do
+      expect(bwapi.instance_variable_get(:@client_secret)).to eql(nil)
+    end
+
+    it 'should reset the connection value' do
+      expect(bwapi.instance_variable_get(:@connection)).to eql(nil)
+    end
+
+    it 'should reset the debug value' do
+      expect(bwapi.debug).to eql(nil)
+    end
+
+    it 'should reset the grant_type value' do
+      expect(bwapi.grant_type).to eql(nil)
+    end
+
+    it 'should reset the logger value' do
+      expect(bwapi.logger).to eql(nil)
+    end
+
+    it 'should reset the password value' do
+      expect(bwapi.instance_variable_get(:@password)).to eql(nil)
+    end
+
+    it 'should reset the performance value' do
+      expect(bwapi.performance).to eql(nil)
+    end
+
+    it 'should reset the refresh_token value' do
+      expect(bwapi.refresh_token).to eql(nil)
+    end
+
+    it 'should reset the user_agent value' do
+      expect(bwapi.user_agent).to eql(nil)
+    end
+
+    it 'should reset the username value' do
+      expect(bwapi.username).to eql(nil)
+    end
+
+    it 'should reset the verify_ssl value' do
+      expect(bwapi.verify_ssl).to eql(nil)
+    end
+  end
+
+  describe '.options' do
+    before { bwapi.reset }
+
+    it 'should return the current configuration set' do
+      expect(bwapi.send(:options)).to eql(
+        access_token: nil,
+        access_token_expiry: nil,
+        adapter: :net_http,
+        api_endpoint: 'https://newapi.brandwatch.com/',
+        client_id: 'brandwatch-api-client',
+        client_secret: nil,
+        connection_options:  {
+          headers:  {
+            user_agent: 'BWAPI Ruby Gem 10.0.0'
+          },
+          request: {
+            params_encoder: Faraday::FlatParamsEncoder
+          }
+        },
+        debug: false,
+        grant_type: 'api-password',
+        logger: nil,
+        password: nil,
+        performance: {},
+        refresh_token: nil,
+        user_agent: 'BWAPI Ruby Gem 10.0.0',
+        username: nil,
+        verify_ssl: false
+      )
+    end
+  end
+end

--- a/spec/bwapi/default_spec.rb
+++ b/spec/bwapi/default_spec.rb
@@ -1,0 +1,242 @@
+require 'helper'
+
+describe BWAPI::Default do
+  describe 'constants' do
+    it 'should have an ADAPTER constant with a default value' do
+      expect(BWAPI::Default::ADAPTER).to eql(:net_http)
+    end
+
+    it 'should have an API_ENDPOINT constant with a default value' do
+      expect(BWAPI::Default::API_ENDPOINT).to eql('https://newapi.brandwatch.com/')
+    end
+
+    it 'should have an CLIENT_ID constant with a default value' do
+      expect(BWAPI::Default::CLIENT_ID).to eql('brandwatch-api-client')
+    end
+
+    it 'should have an GRANT_TYPE constant with a default value' do
+      expect(BWAPI::Default::GRANT_TYPE).to eql('api-password')
+    end
+
+    it 'should have an USER_AGENT constant with a default value' do
+      expect(BWAPI::Default::USER_AGENT).to eql("BWAPI Ruby Gem #{BWAPI::VERSION}")
+    end
+  end
+
+  describe '.options' do
+    it 'should return the configuration keys' do
+      expect(BWAPI::Default.options).to eql(
+        access_token: nil,
+        access_token_expiry: nil,
+        adapter: :net_http,
+        api_endpoint: 'https://newapi.brandwatch.com/',
+        client_id: 'brandwatch-api-client',
+        client_secret: nil,
+        connection_options:  {
+          headers:  {
+            user_agent: 'BWAPI Ruby Gem 10.0.0'
+          },
+          request: {
+            params_encoder: Faraday::FlatParamsEncoder
+          }
+        },
+        debug: false,
+        grant_type: 'api-password',
+        logger: nil,
+        password: nil,
+        performance: {},
+        refresh_token: nil,
+        user_agent: 'BWAPI Ruby Gem 10.0.0',
+        username: nil,
+        verify_ssl: false
+      )
+    end
+  end
+
+  describe '.access_token' do
+    after { ENV['BWAPI_ACCESS_TOKEN'] = nil }
+
+    it 'should return nil when no environmental variable is set' do
+      expect(BWAPI::Default.access_token).to eql(nil)
+    end
+
+    it 'should return the correct value when the environment variable is set' do
+      ENV['BWAPI_ACCESS_TOKEN'] = '1234-5678-9101-1234'
+      expect(BWAPI::Default.access_token).to eql('1234-5678-9101-1234')
+    end
+  end
+
+  describe '.access_token_expiry' do
+    it 'should return nil as default' do
+      expect(BWAPI::Default.access_token_expiry).to eql(nil)
+    end
+  end
+
+  describe '.adapter' do
+    after { ENV['BWAPI_ADAPTER'] = nil }
+
+    it 'should return the default value when no environmental variable is set' do
+      expect(BWAPI::Default.adapter).to eql(:net_http)
+    end
+
+    it 'should return the correct value when the environment variable is set' do
+      ENV['BWAPI_ADAPTER'] = 'test'
+      expect(BWAPI::Default.adapter).to eql(:test)
+    end
+  end
+
+  describe '.api_endpoint' do
+    after { ENV['BWAPI_API_ENDPOINT'] = nil }
+
+    it 'should return the default value when no environmental variable is set' do
+      expect(BWAPI::Default.api_endpoint).to eql('https://newapi.brandwatch.com/')
+    end
+
+    it 'should return the correct value when the environment variable is set' do
+      ENV['BWAPI_API_ENDPOINT'] = 'https://newapi.test.brandwatch.com'
+      expect(BWAPI::Default.api_endpoint).to eql('https://newapi.test.brandwatch.com')
+    end
+  end
+
+  describe '.client_id' do
+    after { ENV['BWAPI_CLIENT_ID'] = nil }
+
+    it 'should return the default value when no environmental variable is set' do
+      expect(BWAPI::Default.client_id).to eql('brandwatch-api-client')
+    end
+
+    it 'should return the correct value when the environment variable is set' do
+      ENV['BWAPI_CLIENT_ID'] = 'brandwatch-test-client'
+      expect(BWAPI::Default.client_id).to eql('brandwatch-test-client')
+    end
+  end
+
+  describe '.client_secret' do
+    after { ENV['BWAPI_CLIENT_SECRET'] = nil }
+
+    it 'should return nil as default' do
+      expect(BWAPI::Default.client_secret).to eql(nil)
+    end
+
+    it 'should return the correct value when the environment variable is set' do
+      ENV['BWAPI_CLIENT_SECRET'] = 'secret'
+      expect(BWAPI::Default.client_secret).to eql('secret')
+    end
+  end
+
+  describe '.connection_options' do
+    it 'should return the default hash values' do
+      expect(BWAPI::Default.connection_options).to eql(
+        headers: {
+          user_agent: 'BWAPI Ruby Gem 10.0.0'
+        },
+        request: {
+          params_encoder: Faraday::FlatParamsEncoder
+        }
+      )
+    end
+  end
+
+  describe '.debug' do
+    after { ENV['BWAPI_DEBUG'] = nil }
+
+    it 'should return false as default' do
+      expect(BWAPI::Default.debug).to eql(false)
+    end
+
+    it 'should return the correct value when the environment variable is set' do
+      ENV['BWAPI_DEBUG'] = 'true'
+      expect(BWAPI::Default.debug).to eql(true)
+    end
+  end
+
+  describe '.grant_type' do
+    after { ENV['BWAPI_GRANT_TYPE'] = nil }
+
+    it 'should return the default value when no environmental variable is set' do
+      expect(BWAPI::Default.grant_type).to eql('api-password')
+    end
+
+    it 'should return the correct value when the environment variable is set' do
+      ENV['BWAPI_GRANT_TYPE'] = 'test-grant'
+      expect(BWAPI::Default.grant_type).to eql('test-grant')
+    end
+  end
+
+  describe '.logger' do
+    it 'should return nil as default' do
+      expect(BWAPI::Default.logger).to eql(nil)
+    end
+  end
+
+  describe '.password' do
+    after { ENV['BWAPI_PASSWORD'] = nil }
+
+    it 'should return nil as default' do
+      expect(BWAPI::Default.password).to eql(nil)
+    end
+
+    it 'should return the correct value when the environment variable is set' do
+      ENV['BWAPI_PASSWORD'] = 'p455word'
+      expect(BWAPI::Default.password).to eql('p455word')
+    end
+  end
+
+  describe '.performance' do
+    it 'should return an empty hash as default' do
+      expect(BWAPI::Default.performance).to eql({})
+    end
+  end
+
+  describe '.refresh_token' do
+    after { ENV['BWAPI_REFRESH_TOKEN'] = nil }
+
+    it 'should return nil as default' do
+      expect(BWAPI::Default.refresh_token).to eql(nil)
+    end
+
+    it 'should return the correct value when the environment variable is set' do
+      ENV['BWAPI_REFRESH_TOKEN'] = '1234-5678-9101-1234'
+      expect(BWAPI::Default.refresh_token).to eql('1234-5678-9101-1234')
+    end
+  end
+
+  describe '.user_agent' do
+    after { ENV['BWAPI_USER_AGENT'] = nil }
+
+    it 'should return the default value when no environmental variable is set' do
+      expect(BWAPI::Default.user_agent).to eql("BWAPI Ruby Gem #{BWAPI::VERSION}")
+    end
+
+    it 'should return the correct value when the environment variable is set' do
+      ENV['BWAPI_USER_AGENT'] = 'Test User Agent'
+      expect(BWAPI::Default.user_agent).to eql('Test User Agent')
+    end
+  end
+
+  describe '.username' do
+    after { ENV['BWAPI_USERNAME'] = nil }
+
+    it 'should return nil as default' do
+      expect(BWAPI::Default.username).to eql(nil)
+    end
+
+    it 'should return the correct value when the environment variable is set' do
+      ENV['BWAPI_USERNAME'] = 'test@brandwatch.com'
+      expect(BWAPI::Default.username).to eql('test@brandwatch.com')
+    end
+  end
+
+  describe '.verify_ssl' do
+    after { ENV['BWAPI_VERIFY_SSL'] = nil }
+
+    it 'should return false as default' do
+      expect(BWAPI::Default.verify_ssl).to eql(false)
+    end
+
+    it 'should return the correct value when the environment variable is set' do
+      ENV['BWAPI_VERIFY_SSL'] = 'true'
+      expect(BWAPI::Default.verify_ssl).to eql(true)
+    end
+  end
+end


### PR DESCRIPTION
## Changes

* Added new method to check if the access_token has been expired and added a check within the authenticated? method. 
* Added new instance variable on the client instance (access_token_expiry) which returns the date

## Results
Ran the unit and rubocop tests as per the contriibuting guidelines:
```
108 files inspected, no offenses detected
Finished in 0.02969 seconds (files took 0.99518 seconds to load)
41 examples, 0 failures
```