### PR TITLE
Updated version to 10.1.0 so that pre releases get bumped

### DIFF
--- a/lib/bwapi/version.rb
+++ b/lib/bwapi/version.rb
@@ -1,4 +1,4 @@
 # BWAPI Version
 module BWAPI
-  VERSION = '10.0.0'
+  VERSION = '10.1.0'
 end


### PR DESCRIPTION
There is an issue with using this gem with the pre releases
The framework gem file uses a pre release gem, and a dependency uses the 10.0.0 release, when bundle install is run both are installed, if you run the framework without bundle exec then gem 10.0 gets run as it is deemed the newest.
if you look at the BWAPI ruby gems page, it looks as if the 10.0 pre release gems are put before the 10.0 gem, so the system will use the 10.0 gem over the 10.0 pre releases.
I am proposing that we bump the version to 10.1 so that all pre releases will be a 10.1 pre release.
this way if anyone installs the BWAPI gem they will get gem 10.0 and if they install with the `--pre` flag they will get the 10.1 pre release.
My theory also is that merging this PR should create the first 10.1 pre release gem and so fix any versioning issues.
