### PR TITLE
NoTask Fixing client clients typo

### DIFF
--- a/lib/bwapi/client/brandwatch/clients/command_center.rb
+++ b/lib/bwapi/client/brandwatch/clients/command_center.rb
@@ -7,7 +7,7 @@ module BWAPI
   class Client
     module Brandwatch
       module Clients
-        # CommandCenter module for brandwatch/client/{client_id}/commandcenter endpoints
+        # CommandCenter module for brandwatch/clients/{client_id}/commandcenter endpoints
         module CommandCenter
           include BWAPI::Client::Brandwatch::Clients::CommandCenter::Limits
           include BWAPI::Client::Brandwatch::Clients::CommandCenter::SceneTypes

--- a/lib/bwapi/client/brandwatch/clients/command_center/limits.rb
+++ b/lib/bwapi/client/brandwatch/clients/command_center/limits.rb
@@ -3,7 +3,7 @@ module BWAPI
     module Brandwatch
       module Clients
         module CommandCenter
-          # Limits module for brandwatch/client/{client_id}/commandcenter/limits endpoints
+          # Limits module for brandwatch/clients/{client_id}/commandcenter/limits endpoints
           module Limits
             # Fetch configured limits for a Vizia client
             #

--- a/lib/bwapi/client/brandwatch/clients/command_center/scene_types.rb
+++ b/lib/bwapi/client/brandwatch/clients/command_center/scene_types.rb
@@ -3,7 +3,7 @@ module BWAPI
     module Brandwatch
       module Clients
         module CommandCenter
-          # SceneTypes module for brandwatch/client/{client_id}/commandcenter/scenetypes endpoints
+          # SceneTypes module for brandwatch/clients/{client_id}/commandcenter/scenetypes endpoints
           module SceneTypes
             # Fetch all scene types enabled for given client
             #

--- a/lib/bwapi/client/brandwatch/clients/command_center/themes.rb
+++ b/lib/bwapi/client/brandwatch/clients/command_center/themes.rb
@@ -9,14 +9,14 @@ module BWAPI
             #
             # TODO: Add parameters documentation
             def brandwatch_themes(client_id)
-              get "brandwatch/client/#{client_id}/commandcenter/themes"
+              get "brandwatch/clients/#{client_id}/commandcenter/themes"
             end
 
             # Alter Vizia themes enabled for client
             #
             # TODO: Add parameters documentation
             def brandwatch_update_themes(client_id, opts = {})
-              get "brandwatch/client/#{client_id}/commandcenter/themes", opts
+              get "brandwatch/clients/#{client_id}/commandcenter/themes", opts
             end
           end
         end

--- a/lib/bwapi/client/brandwatch/clients/command_center/users.rb
+++ b/lib/bwapi/client/brandwatch/clients/command_center/users.rb
@@ -11,14 +11,14 @@ module BWAPI
             #
             # TODO: Add parameters documentation
             def brandwatch_users_access_levels(client_id)
-              get "brandwatch/client/#{client_id}/commandcenter/users"
+              get "brandwatch/clients/#{client_id}/commandcenter/users"
             end
 
             # Fetch a single user's Vizia access level
             #
             # TODO: Add parameters documentation
             def brandwatch_user_access_level(client_id, user_id)
-              get "brandwatch/client/#{client_id}/commandcenter/users/#{user_id}"
+              get "brandwatch/clients/#{client_id}/commandcenter/users/#{user_id}"
             end
 
             include BWAPI::Client::Brandwatch::Clients::CommandCenter::Users::Access

--- a/lib/bwapi/client/brandwatch/clients/command_center/users/access.rb
+++ b/lib/bwapi/client/brandwatch/clients/command_center/users/access.rb
@@ -10,14 +10,14 @@ module BWAPI
               #
               # TODO: Add parameters documentation
               def brandwatch_update_user_access_level(client_id, user_id, access_level)
-                put "brandwatch/client/#{client_id}/commandcenter/users/#{user_id}/access/#{access_level}"
+                put "brandwatch/clients/#{client_id}/commandcenter/users/#{user_id}/access/#{access_level}"
               end
 
               # Revoke a user's Vizia access
               #
               # TODO: Add parameters documentation
               def brandwatch_delete_user_access_level(client_id, user_id, access_level)
-                delete "brandwatch/client/#{client_id}/commandcenter/users/#{user_id}/access/#{access_level}"
+                delete "brandwatch/clients/#{client_id}/commandcenter/users/#{user_id}/access/#{access_level}"
               end
             end
           end

--- a/lib/bwapi/client/brandwatch/clients/modules.rb
+++ b/lib/bwapi/client/brandwatch/clients/modules.rb
@@ -2,7 +2,7 @@ module BWAPI
   class Client
     module Brandwatch
       module Clients
-        # Clientmodules module for brandwatch/client/modules endpoints
+        # Clientmodules module for brandwatch/clients/{client_id}/modules endpoints
         module Modules
           # Get a specific clients modules
           #


### PR DESCRIPTION
### Details
There looks to be a few copy and paste errors causing some endpoints to fail
I have updated the endpoints that need to be `/clients/`

### Results
- Ran rubocop and rspec
