### PR TITLE
NRP-3198-move query endpoint

### DIFF
--- a/lib/bwapi/client/projects/queries.rb
+++ b/lib/bwapi/client/projects/queries.rb
@@ -1,6 +1,7 @@
 require 'bwapi/client/projects/queries/backfill'
 require 'bwapi/client/projects/queries/date_range'
 require 'bwapi/client/projects/queries/mentions'
+require 'bwapi/client/projects/queries/move'
 
 module BWAPI
   class Client
@@ -96,6 +97,7 @@ module BWAPI
         include BWAPI::Client::Projects::Queries::Backfill
         include BWAPI::Client::Projects::Queries::DateRange
         include BWAPI::Client::Projects::Queries::Mentions
+        include BWAPI::Client::Projects::Queries::Move
       end
     end
   end

--- a/lib/bwapi/client/projects/queries/move.rb
+++ b/lib/bwapi/client/projects/queries/move.rb
@@ -1,0 +1,20 @@
+module BWAPI
+  class Client
+    module Projects
+      module Queries
+        # Move module for queries endpoints
+        module Move
+          # Move query to different project
+          #
+          # @param project_id [Integer] Id of original project
+          # @param query_id [Integer] Id of original query
+          # @param dest_project_id [Integer] Id of destination project
+          # @return [Hash] Returns move status
+          def update_move(project_id, query_id, dest_project_id)
+            post "/projects/#{project_id}/queries/#{query_id}/move/#{dest_project_id}"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
New endpoint for move query between projects within that same client. 

Rake
```
coruscant-2:bwapi lukaszmac$ rspec spec
............................................................................................................................................

Finished in 0.07229 seconds (files took 1.94 seconds to load)
140 examples, 0 failures

```