### PR TITLE
NoTask - updates to version dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
 - 2.1.0
 - 2.0.0
 - 1.9.3
-- 1.9.2
 
 script:
   - bundle exec rspec

--- a/bwapi.gemspec
+++ b/bwapi.gemspec
@@ -12,17 +12,17 @@ Gem::Specification.new do |s|
   s.email       = 'jonathan@brandwatch.com'
   s.license     = 'MIT'
   s.homepage    = 'https://github.com/jonathanchrisp/bwapi'
-  s.required_ruby_version = '>= 1.9.2'
+  s.required_ruby_version = '>= 1.9.3'
 
-  s.add_development_dependency 'rspec', '~> 3.0.0'
-  s.add_development_dependency 'rubocop', '~> 0.24.1'
+  s.add_development_dependency 'rspec', '~> 3.0'
+  s.add_development_dependency 'rubocop', '~> 0.24'
 
-  s.add_runtime_dependency 'allotment', '~> 1.1.0'
-  s.add_runtime_dependency 'faraday', '~> 0.9.0'
-  s.add_runtime_dependency 'faraday_middleware', '~> 0.9.1'
+  s.add_runtime_dependency 'allotment', '~> 1.1'
+  s.add_runtime_dependency 'faraday', '~> 0.9'
+  s.add_runtime_dependency 'faraday_middleware', '~> 0.9'
   s.add_runtime_dependency 'faraday_middleware-parse_csv', '~> 0.1'
-  s.add_runtime_dependency 'faraday_middleware-parse_oj', '~> 0.3.0'
-  s.add_runtime_dependency 'oj', '~> 2.11.0'
+  s.add_runtime_dependency 'faraday_middleware-parse_oj', '~> 0.3'
+  s.add_runtime_dependency 'oj', '~> 2.11'
 
   s.files         = `git ls-files`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }

--- a/lib/bwapi/request.rb
+++ b/lib/bwapi/request.rb
@@ -87,7 +87,8 @@ module BWAPI
     # @param opts [Hash] Request parameters
     def request_url(req, path, opts)
       if key?(opts, :force_body)
-        req.path, req.body = path, opts
+        req.path = path
+        req.body = opts
       else
         req.url path, opts
       end
@@ -102,7 +103,8 @@ module BWAPI
       if key?(opts, :force_urlencoded)
         req.url path, opts
       else
-        req.path, req.body = path, opts
+        req.path = path
+        req.body = opts
       end
     end
 

--- a/lib/bwapi/response/performance.rb
+++ b/lib/bwapi/response/performance.rb
@@ -18,7 +18,7 @@ module BWAPI
       end
 
       def call(env)
-        @recording = ("#{env.method}#{env.url.path}").gsub!('/', '_')
+        @recording = ("#{env.method}#{env.url.path}").tr!('/', '_')
         Allotment.start(@recording)
         super
       end

--- a/spec/bwapi/configuration_spec.rb
+++ b/spec/bwapi/configuration_spec.rb
@@ -476,8 +476,8 @@ describe BWAPI::Configuration do
         api_endpoint: 'https://newapi.brandwatch.com/',
         client_id: 'brandwatch-api-client',
         client_secret: nil,
-        connection_options:  {
-          headers:  {
+        connection_options: {
+          headers: {
             user_agent: 'BWAPI Ruby Gem 11.0.1'
           },
           request: {

--- a/spec/bwapi/default_spec.rb
+++ b/spec/bwapi/default_spec.rb
@@ -32,8 +32,8 @@ describe BWAPI::Default do
         api_endpoint: 'https://newapi.brandwatch.com/',
         client_id: 'brandwatch-api-client',
         client_secret: nil,
-        connection_options:  {
-          headers:  {
+        connection_options: {
+          headers: {
             user_agent: 'BWAPI Ruby Gem 11.0.1'
           },
           request: {


### PR DESCRIPTION
***Changes***
Removed the patch level version from the dependencies.  This is needed to allow us to bump up the version of faraday in the other QA repos.