### PR TITLE
ENT-868: Moving_reseller_endpoints

### DIFF
--- a/lib/bwapi/client.rb
+++ b/lib/bwapi/client.rb
@@ -24,7 +24,9 @@ require 'bwapi/client/public'
 require 'bwapi/client/query_validation'
 require 'bwapi/client/sso'
 require 'bwapi/client/test_search'
+require 'bwapi/client/usage_summary'
 require 'bwapi/client/user'
+
 require 'faraday'
 
 module BWAPI
@@ -56,6 +58,7 @@ module BWAPI
     include BWAPI::Client::QueryValidation
     include BWAPI::Client::SSO
     include BWAPI::Client::TestSearch
+    include BWAPI::Client::UsageSummary
     include BWAPI::Client::User
 
     # Initializes Client

--- a/lib/bwapi/client/admin/reseller.rb
+++ b/lib/bwapi/client/admin/reseller.rb
@@ -16,20 +16,6 @@ module BWAPI
         def reseller_client_mention_usage_report(client_id, opts = {})
           get "/admin/reseller/requestMentionUsageReport/#{client_id}", opts
         end
-
-        # Requests reseller usage summaries
-        #
-        # TODO: Add parameters documentation
-        def reseller_usage_summary
-          get '/admin/reseller/usageSummary'
-        end
-
-        # Requests reseller usage summaries for a specific client
-        #
-        # TODO: Add parameters documentation
-        def reseller_client_usage_summary(client_id)
-          get "/admin/reseller/usageSummary/#{client_id}"
-        end
       end
     end
   end

--- a/lib/bwapi/client/usage_summary.rb
+++ b/lib/bwapi/client/usage_summary.rb
@@ -1,0 +1,20 @@
+module BWAPI
+  class Client
+    # UsageSummary module for usageSummary endpoints
+    module UsageSummary
+      # Requests reseller usage summaries
+      #
+      # TODO: Add parameters documentation
+      def reseller_usage_summary(opts = {})
+        get 'reseller/usageSummary', opts
+      end
+
+      # Requests reseller usage summaries for a specific client
+      #
+      # TODO: Add parameters documentation
+      def reseller_client_usage_summary(client_id)
+        get "reseller/usageSummary/#{client_id}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR will move these endpoint from /admin module to a new /reseller module so regular users can use them.
GET /reseller/usageSummary Requests reseller usage summaries
GET /reseller/usageSummary/{clientId} Requests reseller usage summaries for a specific client

Rubocop: 153 files inspected, no offenses detected

 pry(main)> bw.reseller_usage_summary(pitchClientsOnly:true)
=> {"resultsTotal"=>12,
 "resultsPage"=>-1,
 "resultsPageSize"=>-1,
 "results"=>
  [{"clientId"=>372,
    "clientName"=>"new_pitch",
    "packageName"=>"Pitch Pricing",
    "queryCount"=>0,


 pry(main)> bw.reseller_client_usage_summary(361)
=> {"clientId"=>361,
 "clientName"=>"PITCH CLIENT2016",
 "packageName"=>"Pitch Pricing",
 "queryCount"=>1,
 "queryLimit"=>10,
 "mentionCount"=>341,
 "mentionLimit"=>1000,
 "projectCount"=>1,
 "startDate"=>"2015-09-22T00:00:00.000+0000",
 "endDate"=>"2015-10-06T00:00:00.000+0000",
 "numberOfUsers"=>1,
 "enabled"=>true,
