### PR TITLE
Adding a timeout to the request options configuration for Faraday

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,14 @@ language: ruby
 cache: bundler
 rvm:
 - ruby-head
+- 2.2.0
 - 2.1.0
 - 2.0.0
 - 1.9.3
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
 
 script:
   - bundle exec rspec

--- a/lib/bwapi/configuration.rb
+++ b/lib/bwapi/configuration.rb
@@ -2,7 +2,8 @@ module BWAPI
   # Configuration module
   module Configuration
     attr_accessor :access_token, :access_token_expiry, :adapter, :api_endpoint, :client_id, :debug,
-                  :grant_type, :logger, :performance, :refresh_token, :user_agent, :username, :verify_ssl
+                  :grant_type, :logger, :open_timeout, :performance, :refresh_token, :timeout,
+                  :user_agent, :username, :verify_ssl
 
     attr_writer :client_secret, :password
 
@@ -20,9 +21,11 @@ module BWAPI
           :debug,
           :grant_type,
           :logger,
+          :open_timeout,
           :password,
           :performance,
           :refresh_token,
+          :timeout,
           :user_agent,
           :username,
           :verify_ssl

--- a/lib/bwapi/connection.rb
+++ b/lib/bwapi/connection.rb
@@ -25,6 +25,8 @@ module BWAPI
       opts[:headers][:authorization] = "bearer #{@access_token}" if @access_token
       opts[:builder]                 = middleware
       opts[:ssl]                     = { verify: @verify_ssl }
+      opts[:request][:timeout]       = @timeout
+      opts[:request][:open_timeout]  = @open_timeout
       opts[:url]                     = @api_endpoint
       opts
     end

--- a/lib/bwapi/default.rb
+++ b/lib/bwapi/default.rb
@@ -69,6 +69,10 @@ module BWAPI
         nil
       end
 
+      def open_timeout
+        ENV['OPEN_TIMEOUT'] || 30
+      end
+
       def password
         ENV['BWAPI_PASSWORD']
       end
@@ -79,6 +83,10 @@ module BWAPI
 
       def refresh_token
         ENV['BWAPI_REFRESH_TOKEN']
+      end
+
+      def timeout
+        ENV['TIMEOUT'] || 60
       end
 
       def user_agent

--- a/lib/bwapi/version.rb
+++ b/lib/bwapi/version.rb
@@ -1,4 +1,4 @@
 # BWAPI Version
 module BWAPI
-  VERSION = '12.0.0'
+  VERSION = '12.1.0'
 end

--- a/spec/bwapi/configuration_spec.rb
+++ b/spec/bwapi/configuration_spec.rb
@@ -240,9 +240,11 @@ describe BWAPI::Configuration do
         :debug,
         :grant_type,
         :logger,
+        :open_timeout,
         :password,
         :performance,
         :refresh_token,
+        :timeout,
         :user_agent,
         :username,
         :verify_ssl
@@ -262,8 +264,10 @@ describe BWAPI::Configuration do
         c.debug = true
         c.grant_type = 'test-grant'
         c.logger = Logger.new(STDOUT)
+        c.open_timeout = 60
         c.password = 'password123'
         c.refresh_token = '1234-5678-9010-1112'
+        c.timeout = 120
         c.user_agent = 'Test User Agent'
         c.username = 'testing@brandwatch.com'
         c.verify_ssl = true
@@ -305,7 +309,11 @@ describe BWAPI::Configuration do
     end
 
     it 'should set the configured logger' do
-      expect(bwapi.logger).to be_an_instance_of Logger
+      expect(bwapi.logger).to be_an_instance_of(Logger)
+    end
+
+    it 'should set the configured open timeout' do
+      expect(bwapi.open_timeout).to eql(60)
     end
 
     it 'should set the configured password' do
@@ -314,6 +322,10 @@ describe BWAPI::Configuration do
 
     it 'should set the configured refresh_token' do
       expect(bwapi.refresh_token).to eql('1234-5678-9010-1112')
+    end
+
+    it 'should set the configured timeout' do
+      expect(bwapi.timeout).to eql(120)
     end
 
     it 'should set the configured user agent' do
@@ -372,6 +384,10 @@ describe BWAPI::Configuration do
       expect(bwapi.logger).to eql(nil)
     end
 
+    it 'should reset the open timeout' do
+      expect(bwapi.open_timeout).to eql(30)
+    end
+
     it 'should reset the password value' do
       expect(bwapi.instance_variable_get(:@password)).to eql(nil)
     end
@@ -384,8 +400,12 @@ describe BWAPI::Configuration do
       expect(bwapi.refresh_token).to eql(nil)
     end
 
+    it 'should reset the timeout' do
+      expect(bwapi.timeout).to eql(60)
+    end
+
     it 'should reset the user_agent value' do
-      expect(bwapi.user_agent).to eql('BWAPI Ruby Gem 12.0.0')
+      expect(bwapi.user_agent).to eql('BWAPI Ruby Gem 12.1.0')
     end
 
     it 'should reset the username value' do
@@ -440,6 +460,10 @@ describe BWAPI::Configuration do
       expect(bwapi.logger).to eql(nil)
     end
 
+    it 'should reset the open timeout' do
+      expect(bwapi.open_timeout).to eql(nil)
+    end
+
     it 'should reset the password value' do
       expect(bwapi.instance_variable_get(:@password)).to eql(nil)
     end
@@ -450,6 +474,10 @@ describe BWAPI::Configuration do
 
     it 'should reset the refresh_token value' do
       expect(bwapi.refresh_token).to eql(nil)
+    end
+
+    it 'should reset the timeout' do
+      expect(bwapi.open_timeout).to eql(nil)
     end
 
     it 'should reset the user_agent value' do
@@ -478,7 +506,7 @@ describe BWAPI::Configuration do
         client_secret: nil,
         connection_options: {
           headers: {
-            user_agent: 'BWAPI Ruby Gem 12.0.0'
+            user_agent: 'BWAPI Ruby Gem 12.1.0'
           },
           request: {
             params_encoder: Faraday::FlatParamsEncoder
@@ -487,10 +515,12 @@ describe BWAPI::Configuration do
         debug: false,
         grant_type: 'api-password',
         logger: nil,
+        open_timeout: 30,
         password: nil,
         performance: {},
         refresh_token: nil,
-        user_agent: 'BWAPI Ruby Gem 12.0.0',
+        timeout: 60,
+        user_agent: 'BWAPI Ruby Gem 12.1.0',
         username: nil,
         verify_ssl: false
       )

--- a/spec/bwapi/default_spec.rb
+++ b/spec/bwapi/default_spec.rb
@@ -34,7 +34,7 @@ describe BWAPI::Default do
         client_secret: nil,
         connection_options: {
           headers: {
-            user_agent: 'BWAPI Ruby Gem 12.0.0'
+            user_agent: 'BWAPI Ruby Gem 12.1.0'
           },
           request: {
             params_encoder: Faraday::FlatParamsEncoder
@@ -43,10 +43,12 @@ describe BWAPI::Default do
         debug: false,
         grant_type: 'api-password',
         logger: nil,
+        open_timeout: 30,
         password: nil,
         performance: {},
         refresh_token: nil,
-        user_agent: 'BWAPI Ruby Gem 12.0.0',
+        timeout: 60,
+        user_agent: 'BWAPI Ruby Gem 12.1.0',
         username: nil,
         verify_ssl: false
       )
@@ -128,7 +130,7 @@ describe BWAPI::Default do
     it 'should return the default hash values' do
       expect(BWAPI::Default.connection_options).to eql(
         headers: {
-          user_agent: 'BWAPI Ruby Gem 12.0.0'
+          user_agent: 'BWAPI Ruby Gem 12.1.0'
         },
         request: {
           params_encoder: Faraday::FlatParamsEncoder


### PR DESCRIPTION
### Details

- Added open timeout option to BWAPI and added it into the request options for Faraday
- Added timeout option to BWAPI and added it into the request options for Faraday

### Results

```
154 files inspected, no offenses detected

148 examples, 0 failures
1797 / 2264 LOC (79.37%) covered.
```